### PR TITLE
Fixing values for BADCRES (Issue #5) + adding properties to config register

### DIFF
--- a/adafruit_ina219.py
+++ b/adafruit_ina219.py
@@ -161,61 +161,68 @@ class INA219:
 
     @property
     def config(self):
+        """read/write to configuration register - see datasheet for values"""
         return self._read_register(_REG_CONFIG)
-      
+
     @config.setter
-    def config(self,value):
-        self._write_register(_REG_CONFIG,value)
+    def config(self, value):
+        self._write_register(_REG_CONFIG, value)
 
     @property
     def reset(self):
-        self._write_register(_REG_CONFIG,_CONFIG_RESET)
+        """reset the device"""
+        self._write_register(_REG_CONFIG, _CONFIG_RESET)
 
     @property
     def bus_voltage_range(self):
+        """read/write the Bus Voltage Range field of the configuration register"""
         return (self.config & _CONFIG_BVOLTAGERANGE_MASK) >> _CONFIG_BVOLTAGERANGE_LSB
 
     @bus_voltage_range.setter
-    def bus_voltage_range(self,value):
+    def bus_voltage_range(self, value):
         value = (value << _CONFIG_BVOLTAGERANGE_LSB) & _CONFIG_BVOLTAGERANGE_MASK
         self.config = value | (self.config & ~_CONFIG_BVOLTAGERANGE_MASK)
 
     @property
     def gain(self):
+        """read/write the Gain field of the configuration register"""
         return (self.config & _CONFIG_GAIN_MASK) >> _CONFIG_GAIN_LSB
 
     @gain.setter
-    def gain(self,value):
+    def gain(self, value):
         value = (value << _CONFIG_GAIN_LSB) & _CONFIG_GAIN_MASK
         self.config = value | (self.config & ~_CONFIG_GAIN_MASK)
 
     @property
     def bus_adc_res(self):
+        """read/write the Bus ADC Resolution/Averaging field fo the configuration register"""
         return (self.config & _CONFIG_BADCRES_MASK) >> _CONFIG_BADCRES_LSB
 
     @bus_adc_res.setter
-    def bus_adc_res(self,value):
+    def bus_adc_res(self, value):
         value = (value << _CONFIG_BADCRES_LSB) & _CONFIG_BADCRES_MASK
         self.config = value | (self.config & ~_CONFIG_BADCRES_MASK)
 
     @property
     def shunt_adc_res(self):
+        """read/write the Shunt ADC Resolution/Averaging field fo the configuration register"""
         return (self.config & _CONFIG_SADCRES_MASK) >> _CONFIG_SADCRES_LSB
 
     @shunt_adc_res.setter
-    def shunt_adc_res(self,value):
+    def shunt_adc_res(self, value):
         value = (value << _CONFIG_SADCRES_LSB) & _CONFIG_SADCRES_MASK
         self.config = value | (self.config & ~_CONFIG_SADCRES_MASK)
 
     @property
     def mode(self):
+        """read/write the Mode field fo the configuration register"""
         return (self.config & _CONFIG_MODE_MASK) >> _CONFIG_MODE_LSB
 
     @mode.setter
-    def mode(self,value):
+    def mode(self, value):
         value = (value << _CONFIG_MODE_LSB) & _CONFIG_MODE_MASK
         self.config = value | (self.config & ~_CONFIG_MODE_MASK)
-        
+
     @property
     def shunt_voltage(self):
         """The shunt voltage (between V+ and V-) in Volts (so +-.327V)"""

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -21,6 +21,7 @@ while True:
     shunt_voltage = ina219.shunt_voltage
     current = ina219.current
 
+    # INA219 measure bus voltage on the load side. So power supply voltage = busVoltage+shuntVoltage
     print("PSU Voltage:   {:6.3f} V".format(bus_voltage + shunt_voltage))
     print("Shunt Voltage: {:9.6f} V".format(shunt_voltage))
     print("Load Voltage:  {:6.3f} V".format(bus_voltage))

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -9,13 +9,22 @@ i2c_bus = busio.I2C(SCL, SDA)
 
 ina219 = adafruit_ina219.INA219(i2c_bus)
 
+# change configuration to use 32 samples averaging for both bus voltage and shunt voltage
+ina219.bus_adc_res = 0x0D       # BADCRES_12BIT_32S_17MS
+ina219.shunt_adc_res = 0x0D     # SADCRES_12BIT_32S_17MS
+ina219.bus_voltage_range = 0    # BVOLTAGERANGE_16V
+
 print("ina219 test")
 
 while True:
-    print("Bus Voltage:   {} V".format(ina219.bus_voltage))
-    print("Shunt Voltage: {} mV".format(ina219.shunt_voltage / 1000))
-    print("Load Voltage:  {} V".format(ina219.bus_voltage + ina219.shunt_voltage))
-    print("Current:       {} mA".format(ina219.current))
+    bus_voltage = ina219.bus_voltage
+    shunt_voltage = ina219.shunt_voltage
+    current = ina219.current
+
+    print("PSU Voltage:   {:6.3f} V".format(bus_voltage + shunt_voltage))
+    print("Shunt Voltage: {:9.6f} V".format(shunt_voltage))
+    print("Load Voltage:  {:6.3f} V".format(bus_voltage))
+    print("Current:       {:9.6f} A".format(current/1000))
     print("")
 
     time.sleep(2)


### PR DESCRIPTION
This PR includes :
- Fixing BADCRES values which are not inline with the datasheet*
- Adding missing values to support averaging in BADCRES (sames as SADCRES but shifted)*
- Adding new properties to access the config register either as a whole or broke up by fields
- Updating the sample code to use some of the new properties

* I noticed that the Arduino (C) version of the library have the same issues.