### PR TITLE
set_calibration_16V_5A

### DIFF
--- a/adafruit_ina219.py
+++ b/adafruit_ina219.py
@@ -71,7 +71,6 @@ class Gain:
     DIV_2_80MV              = 0x01      # shunt prog. gain set to /2, 80 mV range
     DIV_4_160MV             = 0x02      # shunt prog. gain set to /4, 160 mV range
     DIV_8_320MV             = 0x03      # shunt prog. gain set to /8, 320 mV range
-    AUTO                    = -1        # shunt prog. gain set to automatic
 
 class ADCResolution:
     """Constants for ``bus_adc_resolution`` or ``shunt_adc_resolution``"""
@@ -484,12 +483,12 @@ class INA219:
         # only supporting 16V at 5000mA max.
 
         # VBUS_MAX = 16V
-        # VSHUNT_MAX = 0.08          (Assumes Gain 2, 80mV)
+        # VSHUNT_MAX = 0.16          (Assumes Gain 3, 160mV)
         # RSHUNT = 0.02              (Resistor value in ohms)
 
         # 1. Determine max possible current
         # MaxPossible_I = VSHUNT_MAX / RSHUNT
-        # MaxPossible_I = 4.0A
+        # MaxPossible_I = 8.0A
 
         # 2. Determine max expected current
         # MaxExpected_I = 5.0A
@@ -513,7 +512,7 @@ class INA219:
 
         # 6. Calculate the power LSB
         # PowerLSB = 20 * CurrentLSB
-        # PowerLSB = 0.001 (1mW per bit)
+        # PowerLSB = 0.003 (3.048mW per bit)
         self._power_lsb = 0.003048
 
         # 7. Compute the maximum current and shunt voltage values before overflow
@@ -526,7 +525,7 @@ class INA219:
 
         # Set Config register to take into account the settings above
         self.bus_voltage_range = BusVoltageRange.RANGE_16V
-        self.gain = Gain.AUTO
+        self.gain = Gain.DIV_4_160MV
         self.bus_adc_resolution = ADCResolution.ADCRES_12BIT_1S
         self.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_1S
         self.mode = Mode.SANDBVOLT_CONTINUOUS

--- a/adafruit_ina219.py
+++ b/adafruit_ina219.py
@@ -477,7 +477,11 @@ class INA219:
         self.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_1S
         self.mode = Mode.SANDBVOLT_CONTINUOUS
 
-    def set_calibration_16V_5A(self):
+    def set_calibration_16V_5A(self): # pylint: disable=invalid-name
+        """Configures to INA219 to be able to measure up to 16V and 5000mA of current. Counter
+           overflow occurs at 8.0A.
+
+           .. note:: These calculations assume a 0.02 ohm shunt resistor is present"""
         # Calibration which uses the highest precision for
         # current measurement (0.1mA), at the expense of
         # only supporting 16V at 5000mA max.

--- a/adafruit_ina219.py
+++ b/adafruit_ina219.py
@@ -71,6 +71,7 @@ class Gain:
     DIV_2_80MV              = 0x01      # shunt prog. gain set to /2, 80 mV range
     DIV_4_160MV             = 0x02      # shunt prog. gain set to /4, 160 mV range
     DIV_8_320MV             = 0x03      # shunt prog. gain set to /8, 320 mV range
+    AUTO                    = -1        # shunt prog. gain set to automatic
 
 class ADCResolution:
     """Constants for ``bus_adc_resolution`` or ``shunt_adc_resolution``"""
@@ -501,14 +502,14 @@ class INA219:
 
         # 4. Choose an LSB between the min and max values
         #    (Preferrably a roundish number close to MinLSB)
-        # CurrentLSB = 0.00016 (50uA per bit)
+        # CurrentLSB = 0.00016 (uA per bit)
         self._current_lsb = 0.1524  # in milliamps
 
         # 5. Compute the calibration register
         # Cal = trunc (0.04096 / (Current_LSB * RSHUNT))
-        # Cal = 26869 (0x68f5)
+        # Cal = 13434 (0x347a)
 
-        self._cal_value = 26869
+        self._cal_value = 13434
 
         # 6. Calculate the power LSB
         # PowerLSB = 20 * CurrentLSB
@@ -517,41 +518,15 @@ class INA219:
 
         # 7. Compute the maximum current and shunt voltage values before overflow
         #
-        # Max_Current = Current_LSB * 32767
-        # Max_Current = 1.63835A before overflow
-        #
-        # If Max_Current > Max_Possible_I then
-        #    Max_Current_Before_Overflow = MaxPossible_I
-        # Else
-        #    Max_Current_Before_Overflow = Max_Current
-        # End If
-        #
-        # Max_Current_Before_Overflow = MaxPossible_I
-        # Max_Current_Before_Overflow = 0.4
-        #
-        # Max_ShuntVoltage = Max_Current_Before_Overflow * RSHUNT
-        # Max_ShuntVoltage = 0.04V
-        #
-        # If Max_ShuntVoltage >= VSHUNT_MAX
-        #    Max_ShuntVoltage_Before_Overflow = VSHUNT_MAX
-        # Else
-        #    Max_ShuntVoltage_Before_Overflow = Max_ShuntVoltage
-        # End If
-        #
-        # Max_ShuntVoltage_Before_Overflow = VSHUNT_MAX
-        # Max_ShuntVoltage_Before_Overflow = 0.04V
-
         # 8. Compute the Maximum Power
-        # MaximumPower = Max_Current_Before_Overflow * VBUS_MAX
-        # MaximumPower = 0.4 * 16V
-        # MaximumPower = 6.4W
+        #
 
         # Set Calibration register to 'Cal' calcutated above
         self._raw_calibration = self._cal_value
 
         # Set Config register to take into account the settings above
         self.bus_voltage_range = BusVoltageRange.RANGE_16V
-        self.gain = Gain.DIV_2_80MV
+        self.gain = Gain.AUTO
         self.bus_adc_resolution = ADCResolution.ADCRES_12BIT_1S
         self.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_1S
         self.mode = Mode.SANDBVOLT_CONTINUOUS

--- a/adafruit_ina219.py
+++ b/adafruit_ina219.py
@@ -476,3 +476,82 @@ class INA219:
         self.bus_adc_resolution = ADCResolution.ADCRES_12BIT_1S
         self.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_1S
         self.mode = Mode.SANDBVOLT_CONTINUOUS
+
+    def set_calibration_16V_5A(self):
+        # Calibration which uses the highest precision for
+        # current measurement (0.1mA), at the expense of
+        # only supporting 16V at 5000mA max.
+
+        # VBUS_MAX = 16V
+        # VSHUNT_MAX = 0.08          (Assumes Gain 2, 80mV)
+        # RSHUNT = 0.02              (Resistor value in ohms)
+
+        # 1. Determine max possible current
+        # MaxPossible_I = VSHUNT_MAX / RSHUNT
+        # MaxPossible_I = 4.0A
+
+        # 2. Determine max expected current
+        # MaxExpected_I = 5.0A
+
+        # 3. Calculate possible range of LSBs (Min = 15-bit, Max = 12-bit)
+        # MinimumLSB = MaxExpected_I/32767
+        # MinimumLSB = 0.0001529              (uA per bit)
+        # MaximumLSB = MaxExpected_I/4096
+        # MaximumLSB = 0.0012207              (uA per bit)
+
+        # 4. Choose an LSB between the min and max values
+        #    (Preferrably a roundish number close to MinLSB)
+        # CurrentLSB = 0.00016 (50uA per bit)
+        self._current_lsb = 0.1524  # in milliamps
+
+        # 5. Compute the calibration register
+        # Cal = trunc (0.04096 / (Current_LSB * RSHUNT))
+        # Cal = 26869 (0x68f5)
+
+        self._cal_value = 26869
+
+        # 6. Calculate the power LSB
+        # PowerLSB = 20 * CurrentLSB
+        # PowerLSB = 0.001 (1mW per bit)
+        self._power_lsb = 0.003048
+
+        # 7. Compute the maximum current and shunt voltage values before overflow
+        #
+        # Max_Current = Current_LSB * 32767
+        # Max_Current = 1.63835A before overflow
+        #
+        # If Max_Current > Max_Possible_I then
+        #    Max_Current_Before_Overflow = MaxPossible_I
+        # Else
+        #    Max_Current_Before_Overflow = Max_Current
+        # End If
+        #
+        # Max_Current_Before_Overflow = MaxPossible_I
+        # Max_Current_Before_Overflow = 0.4
+        #
+        # Max_ShuntVoltage = Max_Current_Before_Overflow * RSHUNT
+        # Max_ShuntVoltage = 0.04V
+        #
+        # If Max_ShuntVoltage >= VSHUNT_MAX
+        #    Max_ShuntVoltage_Before_Overflow = VSHUNT_MAX
+        # Else
+        #    Max_ShuntVoltage_Before_Overflow = Max_ShuntVoltage
+        # End If
+        #
+        # Max_ShuntVoltage_Before_Overflow = VSHUNT_MAX
+        # Max_ShuntVoltage_Before_Overflow = 0.04V
+
+        # 8. Compute the Maximum Power
+        # MaximumPower = Max_Current_Before_Overflow * VBUS_MAX
+        # MaximumPower = 0.4 * 16V
+        # MaximumPower = 6.4W
+
+        # Set Calibration register to 'Cal' calcutated above
+        self._raw_calibration = self._cal_value
+
+        # Set Config register to take into account the settings above
+        self.bus_voltage_range = BusVoltageRange.RANGE_16V
+        self.gain = Gain.DIV_2_80MV
+        self.bus_adc_resolution = ADCResolution.ADCRES_12BIT_1S
+        self.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_1S
+        self.mode = Mode.SANDBVOLT_CONTINUOUS

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -7,7 +7,8 @@ from adafruit_ina219 import ADCResolution, BusVoltageRange, INA219
 
 i2c_bus = board.I2C()
 
-ina219 = INA219(i2c_bus)
+ina219 = INA219(i2c_bus, 0x41)
+ina219.set_calibration_16V_5A()
 
 print("ina219 test")
 
@@ -21,10 +22,10 @@ print("  mode:                 0x%1X" % ina219.mode)
 print("")
 
 # optional : change configuration to use 32 samples averaging for both bus voltage and shunt voltage
-ina219.bus_adc_resolution = ADCResolution.ADCRES_12BIT_32S
-ina219.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_32S
+#ina219.bus_adc_resolution = ADCResolution.ADCRES_12BIT_32S
+#ina219.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_32S
 # optional : change voltage range to 16V
-ina219.bus_voltage_range = BusVoltageRange.RANGE_16V
+#ina219.bus_voltage_range = BusVoltageRange.RANGE_16V
 
 # measure and display loop
 while True:

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -39,7 +39,7 @@ while True:
     print("Shunt Voltage: {:9.6f} V".format(shunt_voltage))
     print("Load Voltage:  {:6.3f} V".format(bus_voltage))
     print("Current:       {:9.6f} A".format(current/1000))
-    print("Power:         {:9.6f} W".format(power))
+    print("Power:         {:9.6f} mW".format(power*1000))
     print("")
 
     time.sleep(2)

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -32,12 +32,14 @@ while True:
     bus_voltage = ina219.bus_voltage        # voltage on V- (load side)
     shunt_voltage = ina219.shunt_voltage    # voltage between V+ and V- across the shunt
     current = ina219.current                # current in mA
+    power = ina219.power		    # power in watts
 
     # INA219 measure bus voltage on the load side. So PSU voltage = bus_voltage + shunt_voltage
     print("PSU Voltage:   {:6.3f} V".format(bus_voltage + shunt_voltage))
     print("Shunt Voltage: {:9.6f} V".format(shunt_voltage))
     print("Load Voltage:  {:6.3f} V".format(bus_voltage))
     print("Current:       {:9.6f} A".format(current/1000))
+    print("Power:         {:9.6f} W".format(power))
     print("")
 
     time.sleep(2)

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -7,8 +7,7 @@ from adafruit_ina219 import ADCResolution, BusVoltageRange, INA219
 
 i2c_bus = board.I2C()
 
-ina219 = INA219(i2c_bus, 0x41)
-ina219.set_calibration_16V_5A()
+ina219 = INA219(i2c_bus)
 
 print("ina219 test")
 
@@ -22,24 +21,22 @@ print("  mode:                 0x%1X" % ina219.mode)
 print("")
 
 # optional : change configuration to use 32 samples averaging for both bus voltage and shunt voltage
-#ina219.bus_adc_resolution = ADCResolution.ADCRES_12BIT_32S
-#ina219.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_32S
+ina219.bus_adc_resolution = ADCResolution.ADCRES_12BIT_32S
+ina219.shunt_adc_resolution = ADCResolution.ADCRES_12BIT_32S
 # optional : change voltage range to 16V
-#ina219.bus_voltage_range = BusVoltageRange.RANGE_16V
+ina219.bus_voltage_range = BusVoltageRange.RANGE_16V
 
 # measure and display loop
 while True:
     bus_voltage = ina219.bus_voltage        # voltage on V- (load side)
     shunt_voltage = ina219.shunt_voltage    # voltage between V+ and V- across the shunt
     current = ina219.current                # current in mA
-    power = ina219.power		    # power in watts
 
     # INA219 measure bus voltage on the load side. So PSU voltage = bus_voltage + shunt_voltage
     print("PSU Voltage:   {:6.3f} V".format(bus_voltage + shunt_voltage))
     print("Shunt Voltage: {:9.6f} V".format(shunt_voltage))
     print("Load Voltage:  {:6.3f} V".format(bus_voltage))
     print("Current:       {:9.6f} A".format(current/1000))
-    print("Power:         {:9.6f} mW".format(power*1000))
     print("")
 
     time.sleep(2)


### PR DESCRIPTION
Added a new mode for measuring currents up to 5.0 A.

**Impacts on existing**:
- None expected
- Other modes left unmodified

Mode tested against [Python Library](https://github.com/chrisb2/pi_ina219) which gives correct calculations.

**Further Potential Future Improvements:**
- Expand to allow different shunt resistors on initialisation
- Expand to allow different max_expected current values on initialisation 