### PR TITLE
Add back the last character in constant POWERDOWN.

### DIFF
--- a/adafruit_ina219.py
+++ b/adafruit_ina219.py
@@ -96,7 +96,7 @@ class ADCResolution:
 class Mode:
     """Constants for ``mode``"""
 
-    POWERDOW = 0x00  # power down
+    POWERDOWN = 0x00  # power down
     SVOLT_TRIGGERED = 0x01  # shunt voltage triggered
     BVOLT_TRIGGERED = 0x02  # bus voltage triggered
     SANDBVOLT_TRIGGERED = 0x03  # shunt and bus voltage triggered


### PR DESCRIPTION
It looks like POWERDOWN lost it's 'N' back in c024b6a, this change just puts it back.