### PR TITLE
Improve example outputs

### DIFF
--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -42,4 +42,9 @@ while True:
     print("Power Register : {:6.3f}   W".format(power))
     print("")
 
+    # Check internal calculations haven't overflowed (doesn't detect ADC overflows)
+    if ina219.overflow:
+        print("Internal Math Overflow Detected!")
+        print("")
+
     time.sleep(2)

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -38,7 +38,7 @@ while True:
     print("Voltage (VIN-) : {:6.3f}   V".format(bus_voltage))
     print("Shunt Voltage  : {:8.5f} V".format(shunt_voltage))
     print("Shunt Current  : {:7.4f}  A".format(current / 1000))
-    print("Power Calc.    : {:8.5f} W".format(bus_voltage*(current/1000)))
+    print("Power Calc.    : {:8.5f} W".format(bus_voltage * (current / 1000)))
     print("Power Register : {:6.3f}   W".format(power))
     print("")
 

--- a/examples/ina219_simpletest.py
+++ b/examples/ina219_simpletest.py
@@ -31,12 +31,15 @@ while True:
     bus_voltage = ina219.bus_voltage  # voltage on V- (load side)
     shunt_voltage = ina219.shunt_voltage  # voltage between V+ and V- across the shunt
     current = ina219.current  # current in mA
+    power = ina219.power  # power in watts
 
     # INA219 measure bus voltage on the load side. So PSU voltage = bus_voltage + shunt_voltage
-    print("PSU Voltage:   {:6.3f} V".format(bus_voltage + shunt_voltage))
-    print("Shunt Voltage: {:9.6f} V".format(shunt_voltage))
-    print("Load Voltage:  {:6.3f} V".format(bus_voltage))
-    print("Current:       {:9.6f} A".format(current / 1000))
+    print("Voltage (VIN+) : {:6.3f}   V".format(bus_voltage + shunt_voltage))
+    print("Voltage (VIN-) : {:6.3f}   V".format(bus_voltage))
+    print("Shunt Voltage  : {:8.5f} V".format(shunt_voltage))
+    print("Shunt Current  : {:7.4f}  A".format(current / 1000))
+    print("Power Calc.    : {:8.5f} W".format(bus_voltage*(current/1000)))
+    print("Power Register : {:6.3f}   W".format(power))
     print("")
 
     time.sleep(2)


### PR DESCRIPTION
- Changed naming of 'PSU' and 'Load' voltages to 'VIN+' and 'VIN-' as I initially thought 'PSU' was referring to I2C logic level Vcc. I can't find any IN219 eval boards that don't used VIN+/VIN-. TI datasheet uses 'bus' and 'load' terminology in some circuit diagrams which might have influenced the choice?
- Added power figures both from on chip register (lower resolution) as well as one calculated in Python using the full resolution voltage/current values
- Align output in columns with correct significant figures
- Added prompt if internal math calculations result in an overflow

**_Old_**
```
PSU Voltage:    3.292 V
Shunt Voltage:  0.003520 V
Load Voltage:   3.288 V
Current:        0.035200 A
```

**_New_**
```
Voltage (VIN+) :  3.292   V
Voltage (VIN-) :  3.288   V
Shunt Voltage  :  0.00352 V
Shunt Current  :  0.0352  A
Power Calc.    :  0.11574 W
Power Register :  0.115   W
```

With `gain = DIV_1_40MV` and `_cal_value  = 65535` to force a math overflow in current register.
**_New_**
```
Voltage (VIN+) :  3.128   V
Voltage (VIN-) :  3.088   V
Shunt Voltage  :  0.04000 V
Shunt Current  :  3.2767  A
Power Calc.    : 10.11845 W
Power Register : 10.118   W

Internal Math Overflow Detected!
```