### PR TITLE
Define I2C if busio.I2C import fails

### DIFF
--- a/adafruit_ina219.py
+++ b/adafruit_ina219.py
@@ -37,7 +37,10 @@ try:
     import typing  # pylint: disable=unused-import
     from busio import I2C
 except ImportError:
-    pass
+    # define I2C to avoid the error:
+    # def __init__(self, i2c_bus: I2C, addr: int = 0x40) -> None:
+    # NameError: name 'I2C' is not defined
+    I2C = None
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_INA219.git"


### PR DESCRIPTION
`busio.I2C` gets imported only for the type hint here:

```
class INA219:
    [...]
    def __init__(self, i2c_bus: I2C, addr: int = 0x40) -> None:
```

If the import of `busio.I2C` fails, then the definition of INA219 fails with:

`NameError: name 'I2C' is not defined`

So, instead of passing, I assign a `None` value to `I2C` simply for avoiding that error.

This PR is similar to this one done for another module: https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15/pull/93